### PR TITLE
added catch with error output

### DIFF
--- a/csscomb.js
+++ b/csscomb.js
@@ -29,6 +29,8 @@ process.stdin.on('end', function () {
 
     promise.then(function(string) {
         process.stdout.write(string);
+    }).catch(function(error) {
+        process.stderr.write(error.stack);
     })
 });
 


### PR DESCRIPTION
gives a bit of information about where csscomb crashes instead of the unhandled promise rejection error.